### PR TITLE
Change from Average Rating to Bayesian Rating

### DIFF
--- a/src/services/BggGameService.ts
+++ b/src/services/BggGameService.ts
@@ -204,7 +204,7 @@ class BggGameService {
     }
 
     private getAverageRating(elements: convert.Element[]) {
-        const stringValue = this.getRatingElement(elements).elements.find((t) => t.name === "average").attributes.value;
+        const stringValue = this.getRatingElement(elements).elements.find((t) => t.name === "bayesaverage").attributes.value;
         return parseFloat(stringValue.toString());
     }
 


### PR DESCRIPTION
Issue: games with less number of votes has a higher average rating than popular games. To avoid that BGG has Bayesian Rating https://boardgamegeek.com/wiki/page/ratings

To recreate this issue put user "lendsclub" and select "I prefer games that are highly rated". Games like Brincar+Juntos and Abstratus appear before Puerto Rico and 7 Wonders for example. With Bayesian this is corrected and don't show strange games before highly ranked.